### PR TITLE
Bug during compilation in docker fixed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ all: $(STAT_PRODUCT) $(DYN_PRODUCT)
 
 $(DYN_PRODUCT) : $(OBJS)
 	@echo Linking $(DYN_PRODUCT)
-	@$(CXX) $(LDFLAGS) $(DYN_OPT) -shared $(OBJS) -o $(DYN_PRODUCT)
+	@$(CXX) $(DYN_OPT) -shared $(OBJS) -o $(DYN_PRODUCT) $(LDFLAGS)
 $(STAT_PRODUCT) : $(OBJS)
 	@echo Linking $(STAT_PRODUCT)
 	@$(AR) -rcs $(STAT_PRODUCT) $(OBJS)


### PR DESCRIPTION
My docker container compiles successfully without this pull request, but doing `import GollumFitPy` leads to problems with undefined references. Long story short, this can be fixed by putting the LDFLAGS in the Makefile to the end of the compile command.